### PR TITLE
Allow multiple context provider

### DIFF
--- a/examples/FunctionalFlavour/Api/MessageDescription.php
+++ b/examples/FunctionalFlavour/Api/MessageDescription.php
@@ -83,6 +83,8 @@ final class MessageDescription implements EventEngineDescription
         $eventEngine->registerEvent(Event::FRIEND_CONNECTED, JsonSchema::object([
             UserDescription::IDENTIFIER => $userId,
             UserDescription::FRIEND => $userId,
+            'socialPlatform' => JsonSchema::string(),
+            'matchingHobbies' => JsonSchema::array(JsonSchema::string()),
         ]));
 
         $eventEngine->registerEvent(Event::USER_REGISTRATION_FAILED, JsonSchema::object([

--- a/examples/FunctionalFlavour/ContextProvider/MatchingHobbiesProvider.php
+++ b/examples/FunctionalFlavour/ContextProvider/MatchingHobbiesProvider.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace EventEngineExample\FunctionalFlavour\ContextProvider;
+
+use EventEngineExample\FunctionalFlavour\Command\ConnectWithFriend;
+
+final class MatchingHobbiesProvider
+{
+    public function provide(ConnectWithFriend $command): array
+    {
+        return ['coding', 'EventStorming', 'EventModeling'];
+    }
+}

--- a/examples/FunctionalFlavour/ContextProvider/SocialPlatformProvider.php
+++ b/examples/FunctionalFlavour/ContextProvider/SocialPlatformProvider.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace EventEngineExample\FunctionalFlavour\ContextProvider;
+
+use EventEngineExample\FunctionalFlavour\Command\ConnectWithFriend;
+
+final class SocialPlatformProvider
+{
+    public function provide(ConnectWithFriend $command): string
+    {
+        return 'Github';
+    }
+}

--- a/examples/FunctionalFlavour/Event/FriendConnected.php
+++ b/examples/FunctionalFlavour/Event/FriendConnected.php
@@ -18,4 +18,14 @@ final class FriendConnected
      * @var string
      */
     public $friend;
+
+    /**
+     * @var string
+     */
+    public $socialPlatform;
+
+    /**
+     * @var string[]
+     */
+    public $matchingHobbies;
 }

--- a/examples/OopFlavour/Aggregate/User.php
+++ b/examples/OopFlavour/Aggregate/User.php
@@ -101,13 +101,16 @@ final class User
         ]));
     }
 
-    public function connectWithFriend(ConnectWithFriend $command, GetUserResolver $userResolver): void
+    public function connectWithFriend(ConnectWithFriend $command, string $socialPlatform, array $matchingHobbies, GetUserResolver $userResolver): void
     {
         $friend = $userResolver->resolve(new GetUser(['userId' => $command->friend]));
 
         $this->recordThat(new FriendConnected([
             'userId' => $this->userId,
-            'friend' => $friend['userId']
+            'friend' => $friend['userId'],
+            //Context providers can provide additional data that is not part of current aggregate state or command
+            'socialPlatform' => $socialPlatform,
+            'matchingHobbies' => $matchingHobbies,
         ]));
     }
 

--- a/examples/OopFlavour/Aggregate/UserDescription.php
+++ b/examples/OopFlavour/Aggregate/UserDescription.php
@@ -16,6 +16,8 @@ use EventEngine\EventEngineDescription;
 use EventEngine\Runtime\Oop\FlavourHint;
 use EventEngineExample\FunctionalFlavour\Api\Command;
 use EventEngineExample\FunctionalFlavour\Api\Event;
+use EventEngineExample\FunctionalFlavour\ContextProvider\MatchingHobbiesProvider;
+use EventEngineExample\FunctionalFlavour\ContextProvider\SocialPlatformProvider;
 use EventEngineExample\FunctionalFlavour\Resolver\GetUserResolver;
 
 /**
@@ -76,6 +78,8 @@ final class UserDescription implements EventEngineDescription
     {
         $eventEngine->process(Command::CONNECT_WITH_FRIEND)
             ->withExisting(User::TYPE)
+            ->provideContext(SocialPlatformProvider::class)
+            ->provideContext(MatchingHobbiesProvider::class)
             ->provideService(GetUserResolver::class)
             ->handle([FlavourHint::class, User::class])
             ->recordThat(Event::FRIEND_CONNECTED)

--- a/examples/PrototypingFlavour/ContextProvider/MatchingHobbiesProvider.php
+++ b/examples/PrototypingFlavour/ContextProvider/MatchingHobbiesProvider.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace EventEngineExample\PrototypingFlavour\ContextProvider;
+
+use EventEngine\Aggregate\ContextProvider;
+use EventEngine\Messaging\Message;
+
+final class MatchingHobbiesProvider implements ContextProvider
+{
+    public function provide(Message $connectWithFriend): array
+    {
+        return ['coding', 'EventStorming', 'EventModeling'];
+    }
+}

--- a/examples/PrototypingFlavour/ContextProvider/SocialPlatformProvider.php
+++ b/examples/PrototypingFlavour/ContextProvider/SocialPlatformProvider.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace EventEngineExample\PrototypingFlavour\ContextProvider;
+
+use EventEngine\Aggregate\ContextProvider;
+use EventEngine\Messaging\Message;
+
+final class SocialPlatformProvider implements ContextProvider
+{
+    public function provide(Message $connectWithFriend): string
+    {
+        return 'Github';
+    }
+}

--- a/examples/PrototypingFlavour/Messaging/MessageDescription.php
+++ b/examples/PrototypingFlavour/Messaging/MessageDescription.php
@@ -85,6 +85,8 @@ final class MessageDescription implements EventEngineDescription
         $eventEngine->registerEvent(Event::FRIEND_CONNECTED, JsonSchema::object([
             UserDescription::IDENTIFIER => $userId,
             UserDescription::FRIEND => $userId,
+            'socialPlatform' => JsonSchema::string(),
+            'matchingHobbies' => JsonSchema::array(JsonSchema::string()),
         ]));
 
         $eventEngine->registerEvent(Event::USER_REGISTRATION_FAILED, JsonSchema::object([

--- a/src/Commanding/CommandDispatch.php
+++ b/src/Commanding/CommandDispatch.php
@@ -37,7 +37,7 @@ final class CommandDispatch
      * @param MessageProducer $eventQueue
      * @param EventEngine $eventEngine
      * @param DocumentStore|null $documentStore
-     * @param ContextProvider|mixed|null $contextProvider
+     * @param ContextProvider[]|mixed[] $contextProviders
      * @param array $services
      * @param bool $forwardMetadata
      * @return CommandDispatchResult
@@ -55,7 +55,7 @@ final class CommandDispatch
         MessageProducer $eventQueue,
         EventEngine $eventEngine,
         DocumentStore $documentStore = null,
-        $contextProvider = null,
+        array $contextProviders = [],
         array $services = [],
         bool $forwardMetadata = false
     ): CommandDispatchResult
@@ -72,7 +72,7 @@ final class CommandDispatch
             $log,
             $eventEngine,
             $documentStore,
-            $contextProvider,
+            $contextProviders,
             $services,
             $forwardMetadata
         );

--- a/src/Commanding/CommandProcessorDescription.php
+++ b/src/Commanding/CommandProcessorDescription.php
@@ -66,9 +66,9 @@ final class CommandProcessorDescription
     private $eventRecorderMap = [];
 
     /**
-     * @var string|null
+     * @var string[]|null
      */
-    private $contextProvider;
+    private $contextProviders;
 
     /**
      * @var array
@@ -182,7 +182,11 @@ final class CommandProcessorDescription
 
     public function provideContext(string $contextProvider): self
     {
-        $this->contextProvider = $contextProvider;
+        if(null === $this->contextProviders) {
+            $this->contextProviders = [];
+        }
+
+        $this->contextProviders[] = $contextProvider;
 
         return $this;
     }
@@ -252,7 +256,7 @@ final class CommandProcessorDescription
             'eventRecorderMap' => $eventRecorderMap,
             'streamName' => $this->aggregateStream,
             'multiStoreMode' => $this->multiStoreMode,
-            'contextProvider' => $this->contextProvider,
+            'contextProviders' => $this->contextProviders,
             'services' => $this->services,
         ];
     }

--- a/src/EventEngine.php
+++ b/src/EventEngine.php
@@ -836,6 +836,12 @@ final class EventEngine implements MessageDispatcher, MessageProducer, Aggregate
 
                 $processorDesc = $this->compiledCommandRouting[$command->messageName()] ?? [];
 
+                $contextProviders = $processorDesc['contextProviders'] ?? [];
+
+                foreach ($contextProviders as $cIndex => $cServiceId) {
+                    $contextProviders[$cIndex] = $this->container->get($cServiceId);
+                }
+
                 $services = $processorDesc['services'] ?? [];
 
                 foreach ($services as $sIndex => $serviceId) {
@@ -854,7 +860,7 @@ final class EventEngine implements MessageDispatcher, MessageProducer, Aggregate
                     $this->eventQueue ?? $this,
                     $this,
                     $this->documentStore,
-                    isset($processorDesc['contextProvider']) ? $this->container->get($processorDesc['contextProvider']) : null,
+                    $contextProviders,
                     $services,
                     $this->forwardMetadata
                 );

--- a/tests/EventEngineFunctionalFlavourTest.php
+++ b/tests/EventEngineFunctionalFlavourTest.php
@@ -21,6 +21,8 @@ use EventEngine\Runtime\FunctionalFlavour;
 use EventEngineExample\FunctionalFlavour\Aggregate\UserDescription;
 use EventEngineExample\FunctionalFlavour\Aggregate\UserState;
 use EventEngineExample\FunctionalFlavour\Api\MessageDescription;
+use EventEngineExample\FunctionalFlavour\ContextProvider\MatchingHobbiesProvider;
+use EventEngineExample\FunctionalFlavour\ContextProvider\SocialPlatformProvider;
 use EventEngineExample\FunctionalFlavour\ExampleFunctionalPort;
 use EventEngineExample\FunctionalFlavour\PreProcessor\RegisterUserIfNotExists;
 use EventEngineExample\FunctionalFlavour\ProcessManager\SendWelcomeEmail;
@@ -31,7 +33,7 @@ use EventEngineExample\PrototypingFlavour\Aggregate\UserMetadataProvider;
 
 abstract class EventEngineFunctionalFlavourTest extends EventEngineTestAbstract
 {
-    protected function loadEventMachineDescriptions(EventEngine $eventEngine)
+    protected function loadEventEngineDescriptions(EventEngine $eventEngine)
     {
         $eventEngine->load(MessageDescription::class);
         $eventEngine->load(UserDescription::class);
@@ -65,6 +67,16 @@ abstract class EventEngineFunctionalFlavourTest extends EventEngineTestAbstract
     protected function getUserResolver(array $cachedUserState)
     {
         return new GetUserResolver($cachedUserState);
+    }
+
+    protected function getSocialPlatformProvider()
+    {
+        return new SocialPlatformProvider();
+    }
+
+    protected function getMatchingHobbiesProvider()
+    {
+        return new MatchingHobbiesProvider();
     }
 
     protected function getUsersResolver(array $cachedUsers)

--- a/tests/EventEngineOopFlavourTest.php
+++ b/tests/EventEngineOopFlavourTest.php
@@ -19,6 +19,8 @@ use EventEngine\Runtime\Flavour;
 use EventEngine\Runtime\FunctionalFlavour;
 use EventEngine\Runtime\OopFlavour;
 use EventEngineExample\FunctionalFlavour\Api\MessageDescription;
+use EventEngineExample\FunctionalFlavour\ContextProvider\MatchingHobbiesProvider;
+use EventEngineExample\FunctionalFlavour\ContextProvider\SocialPlatformProvider;
 use EventEngineExample\FunctionalFlavour\ExampleFunctionalPort;
 use EventEngineExample\FunctionalFlavour\PreProcessor\RegisterUserIfNotExists;
 use EventEngineExample\FunctionalFlavour\ProcessManager\SendWelcomeEmail;
@@ -32,7 +34,7 @@ use EventEngineExample\OopFlavour\ExampleOopPortWithUserMetadataProvider;
 
 abstract class EventEngineOopFlavourTest extends EventEngineTestAbstract
 {
-    protected function loadEventMachineDescriptions(EventEngine $eventMachine)
+    protected function loadEventEngineDescriptions(EventEngine $eventMachine)
     {
         $eventMachine->load(MessageDescription::class);
         $eventMachine->load(UserDescription::class);
@@ -72,6 +74,16 @@ abstract class EventEngineOopFlavourTest extends EventEngineTestAbstract
     protected function getUserResolver(array $cachedUserState)
     {
         return new GetUserResolver($cachedUserState);
+    }
+
+    protected function getSocialPlatformProvider()
+    {
+        return new SocialPlatformProvider();
+    }
+
+    protected function getMatchingHobbiesProvider()
+    {
+        return new MatchingHobbiesProvider();
     }
 
     protected function getUsersResolver(array $cachedUsers)

--- a/tests/EventEnginePrototypingFlavourTest.php
+++ b/tests/EventEnginePrototypingFlavourTest.php
@@ -25,6 +25,8 @@ use EventEngine\Runtime\PrototypingFlavour;
 use EventEngineExample\PrototypingFlavour\Aggregate\UserDescription;
 use EventEngineExample\PrototypingFlavour\Aggregate\UserMetadataProvider;
 use EventEngineExample\PrototypingFlavour\Aggregate\UserState;
+use EventEngineExample\PrototypingFlavour\ContextProvider\MatchingHobbiesProvider;
+use EventEngineExample\PrototypingFlavour\ContextProvider\SocialPlatformProvider;
 use EventEngineExample\PrototypingFlavour\Messaging\CommandWithCustomHandler;
 use EventEngineExample\PrototypingFlavour\Messaging\MessageDescription;
 use EventEngineExample\PrototypingFlavour\PreProcessor\RegisterUserIfNotExists;
@@ -36,7 +38,7 @@ use Prophecy\Argument;
 
 abstract class EventEnginePrototypingFlavourTest extends EventEngineTestAbstract
 {
-    protected function loadEventMachineDescriptions(EventEngine $eventEngine)
+    protected function loadEventEngineDescriptions(EventEngine $eventEngine)
     {
         $eventEngine->load(MessageDescription::class);
         $eventEngine->load(UserDescription::class);
@@ -70,6 +72,16 @@ abstract class EventEnginePrototypingFlavourTest extends EventEngineTestAbstract
     protected function getUserResolver(array $cachedUserState): Resolver
     {
         return new GetUserResolver($cachedUserState);
+    }
+
+    protected function getSocialPlatformProvider()
+    {
+        return new SocialPlatformProvider();
+    }
+
+    protected function getMatchingHobbiesProvider()
+    {
+        return new MatchingHobbiesProvider();
     }
 
     protected function getUsersResolver(array $cachedUsers): Resolver


### PR DESCRIPTION
Similar to multiple services it is now also possible to inject multiple contexts into an aggregate handling function. This makes it easier to reuse existing context providers without the need to compose them.

The change is backwards compatible with the exception that the compiled config for an aggregate description has changed. Instead of `contextProvider` it now contains the key `contextProviders` which is a list of serviceIds instead of only one.